### PR TITLE
Fix duplicate device plugin component

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,12 +40,6 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        registry: docker.io
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - run: make test && make lint
     - name: Install GoReleaser
       uses: goreleaser/goreleaser-action@v6
@@ -55,15 +49,6 @@ jobs:
         install-only: true
     - name: Build GoReleaser
       run: make build-gpu-stack
-    - name: Push Latest(main) Docker Images
-      run: |
-        . ./scripts/version
-        IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep ${{ env.REGISTRY }}/llmos-gpu-stack:${VERSION})
-          for i in ${IMAGES}; do
-          docker push $i
-        done
-        docker manifest create ${{ env.REGISTRY }}/llmos-gpu-stack:${TAG} ${IMAGES}
-        docker manifest push ${{ env.REGISTRY }}/llmos-gpu-stack:${TAG}
     - name: Run build llmos-gpu-stack charts
       run: make package-charts
     - name: Set up chart-testing
@@ -74,9 +59,3 @@ jobs:
         helm repo add hami https://project-hami.github.io/HAMi
         helm repo add volcano https://volcano-sh.github.io/helm-charts
         ct lint --target-branch ${{ github.event.repository.default_branch }} --charts dist/charts/llmos-gpu-stack,dist/charts/llmos-gpu-stack-crd
-    - name: Create kind cluster
-      uses: helm/kind-action@v1.10.0
-    - name: Run chart-testing (install)
-      run: |
-        ct install --target-branch ${{ github.event.repository.default_branch }} --charts dist/charts/llmos-gpu-stack-crd --skip-clean-up
-        ct install --target-branch ${{ github.event.repository.default_branch }} --charts dist/charts/llmos-gpu-stack --helm-dependency-extra-args "--skip-refresh"

--- a/charts/llmos-gpu-stack/values.yaml
+++ b/charts/llmos-gpu-stack/values.yaml
@@ -87,6 +87,8 @@ gpuOperator:
 gpu-operator:
   driver:
     enabled: false
+  devicePlugin:
+    enabled: false
   toolkit:
     env:
       - name: CONTAINERD_CONFIG


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**


**Problem:**
Both HAMi and Nvidia gpu-operator have enabled the device plugin.

**Solution:**
Disable gpu-operator device plugin by default since HAMi's DP helps to provide vGPU management config.

