### PR TITLE
Add skip_existing flag to chart upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           charts_dir: dist/charts
           skip_packaging: true
+          skip_existing: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CR_PACKAGE_PATH: dist/charts


### PR DESCRIPTION
Prevent duplicate uploads of existing charts by enabling the skip_existing option
