### PR TITLE
feat(device-plugin): add gpu-memory-factor configuration

### DIFF
--- a/charts/llmos-gpu-stack/templates/nvidia-device-plugin/daemonset.yaml
+++ b/charts/llmos-gpu-stack/templates/nvidia-device-plugin/daemonset.yaml
@@ -51,7 +51,8 @@ spec:
           image: {{ printf "%s/%s:%s" $registry .Values.devicePlugin.image.repository .Values.devicePlugin.image.tag }}
           imagePullPolicy: {{ .Values.devicePlugin.image.pullPolicy }}
           args:
-            - "--device-split-count={{ .Values.devicePlugin.splitCount}}"
+            - "--device-split-count={{ .Values.devicePlugin.splitCount }}"
+            - "--gpu-memory-factor={{ .Values.devicePlugin.gpuMemoryFactor }}"
           lifecycle:
             postStart:
               exec:

--- a/charts/llmos-gpu-stack/values.yaml
+++ b/charts/llmos-gpu-stack/values.yaml
@@ -183,5 +183,6 @@ devicePlugin:
       effect: NoSchedule
   affinity: {}
   splitCount: 10
+  gpuMemoryFactor: 1
   metrics:
     enabled: false


### PR DESCRIPTION
Add new gpuMemoryFactor parameter to device plugin configuration to allow adjusting GPU memory allocation

<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->

**Problem:**
Currently, the GPU device plugin allocates GPU memory in fixed chunks without the ability to adjust the allocation ratio. This can lead to inefficient GPU memory utilization like https://github.com/llmos-ai/llmos/issues/55 , but there's no configuration option to control this behavior.


**Solution:**
This PR introduces a new gpuMemoryFactorparameter to the device plugin configuration that allows administrators to adjust how GPU memory is allocated. The factor is a multiplier applied to the base memory allocation calculation.


**Related Issue:**
https://github.com/llmos-ai/llmos/issues/55

**Test plan:**
1. Manual testing on a cluster with:
  - Default factor (1) to verify backward compatibility
  - Large factor (10) to verify increased allocations `=10MB`
1. Verified that existing deployments without the parameter continue to work as before
